### PR TITLE
Option auto deselect

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,7 @@
             "program": "${workspaceRoot}/build/convertEncoding",
             "args": [
                 "test", 
-                "--usage",
-                "--Blödsinn", "\"ganz viel text in hochkommas\"",
-                "-E", "\"pdf, odt, xls, xlsm,ods\""
+                "-A"
             ],
             "stopAtEntry": true,
             "cwd": "${workspaceRoot}",

--- a/Include/Options.hpp
+++ b/Include/Options.hpp
@@ -39,6 +39,7 @@ class Options
 
         std::list<OptionsInput> PossibleOptions 
         {
+            OptionsInput(std::string("auto_deselect"),	 0u, 'A'),
 	    	OptionsInput(std::string("exclude"), 1u, 'E'),
 		    OptionsInput(std::string("usage"),	 0u, 'U')
     	};
@@ -48,6 +49,7 @@ class Options
         std::list<OptionsInput>::const_iterator equalsLongOption(const char* opt) const;
         std::list<OptionsInput>::const_iterator equalsShortOption(const char* opt) const;
 
+        void setOptionsAutoDeselect();
 };
 
 #endif // OPTIONS

--- a/Source/Options.cpp
+++ b/Source/Options.cpp
@@ -46,6 +46,10 @@ Options::Options(int argc, char** argv)
         }
         // std::cout << "\n";
     }
+
+    if ( this->exists(std::string {"auto_deselect"}) ) {
+        setOptionsAutoDeselect();
+    }
 }
 
 std::list<OptionsInput>::const_iterator Options::equalsLongOption(const char* opt) const
@@ -77,6 +81,7 @@ bool Options::exists(const std::string input) const
 {
     std::map<std::string, std::variant<int, std::string> >::const_iterator found = AllOptions.find(input);
     if ( found != AllOptions.end()) {
+        std::cout << "DEBUG" << found->first << "\n";
         return true;
     }
     return false;
@@ -94,4 +99,14 @@ std::string Options::getExtensionFor(std::string long_name)
         }
     }
     return extension;
+}
+
+void Options::setOptionsAutoDeselect()
+{
+    std::string option {"exclude"};
+    std::string extension { std::string("accdb, asd, avi, bmp, cab, doc, docm, docx, dot, dotm, dotx, exe, gif, gz, jar, jpeg, ") +
+                            std::string("jpg, lib, m4v, mdb, mid, mov, mp3, mp4, mpeg, mpg, ods, odt, pdf, ppt, pptm, pptx, rar") +
+                            std::string(", rec, tar, tif und tiff, tmp, wdb, wks, wmv, wps, xlam, xlk, xll, xls, xlsb, xlsm, ") +
+                            std::string("xlsx, xltx, xps, zip")};
+    AllOptions.insert(std::pair< std::string, std::variant<int, std::string> >(option, extension)) ;
 }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -16,8 +16,12 @@ void print_usage()
     std::cout << PROJECT_NAME << " [path] --usage \n";
     std::cout << "=======================================================\n";
     std::cout << "path\tpath or file name to convert all files recursive \n ";
-    std::cout << "--usage -u to print this \n ";
-    std::cout << "-exclude list of file appendencies to exclude from converting i.e \"xls, pdf, xslm\" \n";
+    std::cout << "-auto_deselect / -A not converting files with the following appendencies accdb, asd, avi, bmp,"
+              << " cab, doc, docm, docx, dot, dotm, dotx, exe, gif, gz, jar, jpeg, jpg, lib, m4v, mdb, mid, mov,"
+              << " mp3, mp4, mpeg, mpg, ods, odt, pdf, ppt, pptm, pptx, rar, rec, tar, tif und tiff, tmp, wdb, wks,"
+              << " wmv, wps, xlam, xlk, xll, xls, xlsb, xlsm, xlsx, xltx, xps, zip \n";
+    std::cout << "--usage / -u to print this \n ";
+    std::cout << "-exclude / -E list of file appendencies to exclude from converting i.e \"xls, pdf, xslm\" \n";
 }
 
 


### PR DESCRIPTION
Excluding a long list of not convertible files with the follwing apendencies.
accdb, asd, avi, bmp, cab, doc, docm, docx, dot, dotm, dotx, exe, gif, gz, 
jar, jpeg, jpg, lib, m4v, mdb, mid, mov,  mp3, mp4, mpeg, mpg, ods, odt, 
pdf, ppt, pptm, pptx, rar, rec, tar, tif und tiff, tmp, wdb, wks, wmv, wps, 
xlam, xlk, xll, xls, xlsb, xlsm, xlsx, xltx, xps, zip 

Fixes #14